### PR TITLE
タスクの入力画面のデザイン変更

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -24,7 +24,7 @@
                                 @error('detail')
                                     {{ $message }}
                                 @enderror
-                                <textarea name="detail" class="form-control" id="exampleFormControlTextarea1" rows="10">{{ $post_data['task_info']['detail'] }}</textarea>
+                                <textarea name="detail" class="form-control" id="exampleFormControlTextarea1" rows="30">{{ $post_data['task_info']['detail'] }}</textarea>
                             </div>
                             <div class="form-group">
                                 <label for="exampleFormControlSelect1">タイムリミット</label>

--- a/resources/views/tasks/register.blade.php
+++ b/resources/views/tasks/register.blade.php
@@ -24,7 +24,7 @@
                                 @error('detail')
                                     {{ $message }}
                                 @enderror
-                                <textarea name="detail" class="form-control" id="exampleFormControlTextarea1" rows="10">{{ old('detail') }}</textarea>
+                                <textarea name="detail" class="form-control" id="exampleFormControlTextarea1" rows="30">{{ old('detail') }}</textarea>
                             </div>
                             <div class="form-group">
                                 <label for="exampleFormControlSelect1">タイムリミット</label>


### PR DESCRIPTION
タスク登録の詳細入力テキストエリアのサイズを拡大
タスク編集の詳細入力テキストエリアのサイズを拡大